### PR TITLE
 feat: Ensure invite keys are in did:key format

### DIFF
--- a/src/auth/did.rs
+++ b/src/auth/did.rs
@@ -29,3 +29,11 @@ pub fn extract_did_data<'a>(did: &'a str, method: &'a str) -> Result<&'a str, Di
         .ok_or(DidError::Format)?;
     Ok(data)
 }
+
+/// Checks whether the provided string is a valid `did` according to the
+/// X25519[1] spec.
+///
+/// [1]: https://w3c-ccg.github.io/did-method-key/#x25519
+pub fn validate_x25519(did: &str) -> bool {
+    did.starts_with("did:key:z6LS")
+}

--- a/src/handlers/invite/mod.rs
+++ b/src/handlers/invite/mod.rs
@@ -15,8 +15,17 @@ pub struct InviteKeyClaims {
     aud: String, // keys server url used for registering
     exp: usize,  // timestamp when jwt must expire TODO: Should be 1 hour
     iat: usize,  // timestamp when jwt was issued
-    iss: String, // public identity key in form of did:key, also used to verify jwt signature
-    sub: String, // public key for chat invite key
+
+    /// Public identity key in form of did:key according to the [Ed25519][1]
+    ///
+    /// [1]: https://w3c-ccg.github.io/did-method-key/#ed25519-x25519
+    iss: String,
+
+    /// Public key for chat invite key in form of did:key according to the [X25519][1]
+    ///
+    /// [1]: https://w3c-ccg.github.io/did-method-key/#x25519
+    sub: String,
+
     pkh: String, // corresponding blockchain account (did:pkh)
 }
 
@@ -26,10 +35,10 @@ impl JwtClaims for InviteKeyClaims {
         // aud must be equal this dns?
         // exp must be in future
         // iat must be in past
-        // sub must be valid public key
+        // iss must be valid did:key
         // pkh must be valid did:pkh
 
-        did::validate_x25519(&self.iss)
+        did::validate_x25519(&self.sub)
     }
 }
 
@@ -59,13 +68,13 @@ mod test_claims_validation {
         let mut claims = default();
         assert!(!claims.is_valid());
 
-        claims.iss = "ababagalamaga".to_string();
+        claims.sub = "ababagalamaga".to_string();
         assert!(!claims.is_valid());
 
-        claims.iss = "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme".to_string();
+        claims.sub = "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme".to_string();
         assert!(!claims.is_valid());
 
-        claims.iss = "did:abc".to_string();
+        claims.sub = "did:abc".to_string();
         assert!(!claims.is_valid());
     }
 
@@ -73,13 +82,13 @@ mod test_claims_validation {
     fn succeeds_on_correct_claims() {
         let mut claims = default();
 
-        claims.iss = "did:key:z6LSeu9HkTHSfLLeUs2nnzUSNedgDUevfNQgQjQC23ZCit6F".to_string();
+        claims.sub = "did:key:z6LSeu9HkTHSfLLeUs2nnzUSNedgDUevfNQgQjQC23ZCit6F".to_string();
         assert!(claims.is_valid());
 
-        claims.iss = "did:key:z6LStiZsmxiK4odS4Sb6JmdRFuJ6e1SYP157gtiCyJKfrYha".to_string();
+        claims.sub = "did:key:z6LStiZsmxiK4odS4Sb6JmdRFuJ6e1SYP157gtiCyJKfrYha".to_string();
         assert!(claims.is_valid());
 
-        claims.iss = "did:key:z6LSoMdmJz2Djah2P4L9taDmtqeJ6wwd2HhKZvNToBmvaczQ".to_string();
+        claims.sub = "did:key:z6LSoMdmJz2Djah2P4L9taDmtqeJ6wwd2HhKZvNToBmvaczQ".to_string();
         assert!(claims.is_valid());
     }
 }

--- a/src/handlers/invite/mod.rs
+++ b/src/handlers/invite/mod.rs
@@ -1,5 +1,8 @@
 use {
-    crate::auth::jwt::{JwtClaims, JwtVerifierByIssuer},
+    crate::auth::{
+        did,
+        jwt::{JwtClaims, JwtVerifierByIssuer},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -19,19 +22,64 @@ pub struct InviteKeyClaims {
 
 impl JwtClaims for InviteKeyClaims {
     fn is_valid(&self) -> bool {
-        true
         // TODO: Add validation:
         // aud must be equal this dns?
         // exp must be in future
         // iat must be in past
-        // iss must be valid did:key
         // sub must be valid public key
         // pkh must be valid did:pkh
+
+        did::validate_x25519(&self.iss)
     }
 }
 
 impl JwtVerifierByIssuer for InviteKeyClaims {
     fn get_iss(&self) -> &str {
         &self.iss
+    }
+}
+
+#[cfg(test)]
+mod test_claims_validation {
+    use super::{InviteKeyClaims, JwtClaims as _};
+
+    fn default() -> InviteKeyClaims {
+        InviteKeyClaims {
+            aud: String::new(),
+            exp: 0,
+            iat: 0,
+            iss: String::new(),
+            sub: String::new(),
+            pkh: String::new(),
+        }
+    }
+
+    #[test]
+    fn fails_on_incorrect_claims() {
+        let mut claims = default();
+        assert!(!claims.is_valid());
+
+        claims.iss = "ababagalamaga".to_string();
+        assert!(!claims.is_valid());
+
+        claims.iss = "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme".to_string();
+        assert!(!claims.is_valid());
+
+        claims.iss = "did:abc".to_string();
+        assert!(!claims.is_valid());
+    }
+
+    #[test]
+    fn succeeds_on_correct_claims() {
+        let mut claims = default();
+
+        claims.iss = "did:key:z6LSeu9HkTHSfLLeUs2nnzUSNedgDUevfNQgQjQC23ZCit6F".to_string();
+        assert!(claims.is_valid());
+
+        claims.iss = "did:key:z6LStiZsmxiK4odS4Sb6JmdRFuJ6e1SYP157gtiCyJKfrYha".to_string();
+        assert!(claims.is_valid());
+
+        claims.iss = "did:key:z6LSoMdmJz2Djah2P4L9taDmtqeJ6wwd2HhKZvNToBmvaczQ".to_string();
+        assert!(claims.is_valid());
     }
 }


### PR DESCRIPTION
# Description

Validates `InviteKeyClaims::iss` to be in [X25519](https://w3c-ccg.github.io/did-method-key/#x25519) format.

Resolves #49

## How Has This Been Tested?


Unit

## Due Diligence

* [ ] Breaking change
* [x] Requires a documentation update
* [ ] Requires a e2e/integration test update
