### PR TITLE
fix: use lb arn suffix in grafana dashboard

### DIFF
--- a/terraform/ecs/outputs.tf
+++ b/terraform/ecs/outputs.tf
@@ -11,6 +11,11 @@ output "load_balancer_arn" {
   value       = aws_alb.network_load_balancer.arn
 }
 
+output "load_balancer_arn_suffix" {
+  description = "The ARN suffix of the load balancer"
+  value       = aws_alb.network_load_balancer.arn_suffix
+}
+
 output "service_name" {
   description = "The name of the service"
   value       = aws_ecs_service.app_service.name

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -75,7 +75,8 @@ module "o11y" {
   prometheus_workspace_id = aws_prometheus_workspace.prometheus.id
   environment             = terraform.workspace
   ecs_service_name        = module.ecs.service_name
-  load_balancer           = module.ecs.load_balancer_arn
+  target_group            = module.ecs.target_group_arn
+  load_balancer           = module.ecs.load_balancer_arn_suffix
   docdb_cluster_id        = module.keystore-docdb.cluster_id
 }
 

--- a/terraform/monitoring/dashboard.tf
+++ b/terraform/monitoring/dashboard.tf
@@ -2,8 +2,8 @@ data "jsonnet_file" "dashboard" {
   source = "${path.module}/dashboard.jsonnet"
 
   ext_str = {
-    dashboard_title = "${var.environment} - _keyserver"
-    dashboard_uid   = "${var.environment}-_keyserver"
+    dashboard_title = "${var.environment} - keyserver"
+    dashboard_uid   = "${var.environment}-keyserver"
 
     prometheus_uid = grafana_data_source.prometheus.uid
     cloudwatch_uid = grafana_data_source.cloudwatch.uid
@@ -11,6 +11,7 @@ data "jsonnet_file" "dashboard" {
     notifications    = jsonencode(local.notifications)
     environment      = var.environment
     ecs_service_name = var.ecs_service_name
+    target_group     = var.target_group
     load_balancer    = var.load_balancer
     docdb_cluster_id = var.docdb_cluster_id
   }

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -11,6 +11,10 @@ variable "ecs_service_name" {
   type = string
 }
 
+variable "target_group" {
+  type = string
+}
+
 variable "load_balancer" {
   type = string
 }


### PR DESCRIPTION
# Description

Use load balancer ARN suffix in Grafana dashboard.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
