### PR TITLE
Fix/scale

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -67,6 +67,25 @@ provider "registry.terraform.io/grafana/grafana" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.3.0"
+  hashes = [
+    "h1:NaDbOqAcA9d8DiAS5/6+5smXwN3/+twJGb3QRiz6pNw=",
+    "zh:0869128d13abe12b297b0cd13b8767f10d6bf047f5afc4215615aabc39c2eb4f",
+    "zh:481ed837d63ba3aa45dd8736da83e911e3509dee0e7961bf5c00ed2644f807b3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9f08fe2977e2166849be24fb9f394e4d2697414d463f7996fd0d7beb4e19a29c",
+    "zh:9fe566deeafd460d27999ca0bbfd85426a5fcfcb40007b23884deb76da127b6f",
+    "zh:a1bd9a60925d9769e0da322e4523330ee86af9dc2e770cba1d0247a999ef29cb",
+    "zh:bb4094c8149f74308b22a87e1ac19bcccca76e8ef021b571074d9bccf1c0c6f0",
+    "zh:c8984c9def239041ce41ec8e19bbd76a49e74ed2024ff736dad60429dee89bcc",
+    "zh:ea4bb5ae73db1de3a586e62f39106f5e56770804a55aa5e6b4f642df973e0e75",
+    "zh:f44a9d596ecc3a8c5653f56ba0cd202ad93b49f76767f4608daf7260b813289e",
+    "zh:f5c5e6cc9f7f070020ab7d95fcc9ed8e20d5cf219978295a71236e22cbb6d508",
+    "zh:fd2273f51dcc8f43403bf1e425ba9db08a57c3ddcba5ad7a51742ccde21ca611",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.75.2"
   constraints = "~> 3.27"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -11,3 +11,58 @@ Use the dev workspace:
 Now you can apply the changes:
 
 `terraform -chdir=terraform apply  -var-file="vars/dev.tfvars"`
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_assert"></a> [assert](#requirement\_assert) | ~> 0.0.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.27 |
+| <a name="requirement_grafana"></a> [grafana](#requirement\_grafana) | ~> 1.24 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_assert"></a> [assert](#provider\_assert) | ~> 0.0.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.27 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_dns"></a> [dns](#module\_dns) | github.com/WalletConnect/terraform-modules/modules/dns | n/a |
+| <a name="module_ecs"></a> [ecs](#module\_ecs) | ./ecs | n/a |
+| <a name="module_keystore-docdb"></a> [keystore-docdb](#module\_keystore-docdb) | ./docdb | n/a |
+| <a name="module_o11y"></a> [o11y](#module\_o11y) | ./monitoring | n/a |
+| <a name="module_tags"></a> [tags](#module\_tags) | github.com/WalletConnect/terraform-modules/modules/tags | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_prometheus_workspace.prometheus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/prometheus_workspace) | resource |
+| [assert_test.workspace](https://registry.terraform.io/providers/bwoznicki/assert/latest/docs/data-sources/test) | data source |
+| [aws_ecr_repository.repository](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_repository) | data source |
+| [aws_subnets.private_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_subnets.public_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_grafana_endpoint"></a> [grafana\_endpoint](#input\_grafana\_endpoint) | The endpoint of the Grafana instance | `string` | n/a | yes |
+| <a name="input_image_version"></a> [image\_version](#input\_image\_version) | The version of the image to deploy | `string` | n/a | yes |
+| <a name="input_keystore_docdb_primary_instance_class"></a> [keystore\_docdb\_primary\_instance\_class](#input\_keystore\_docdb\_primary\_instance\_class) | The instance class of the primary docdb instances | `string` | n/a | yes |
+| <a name="input_keystore_docdb_primary_instances"></a> [keystore\_docdb\_primary\_instances](#input\_keystore\_docdb\_primary\_instances) | The number of primary docdb instances to deploy | `number` | n/a | yes |
+| <a name="input_keystore_docdb_replica_instance_class"></a> [keystore\_docdb\_replica\_instance\_class](#input\_keystore\_docdb\_replica\_instance\_class) | The instance class of the replica docdb instances | `string` | n/a | yes |
+| <a name="input_keystore_docdb_replica_instances"></a> [keystore\_docdb\_replica\_instances](#input\_keystore\_docdb\_replica\_instances) | The number of replica docdb instances to deploy | `number` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS region to deploy to | `string` | `"eu-central-1"` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/terraform/docdb/README.md
+++ b/terraform/docdb/README.md
@@ -1,0 +1,68 @@
+# `docdb` module
+
+Creates a DocumentDB cluster with auto-scaled read replicas.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.27 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | 3.4.3 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.27 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_docdb-autoscaling"></a> [docdb-autoscaling](#module\_docdb-autoscaling) | github.com/theuves/docdb-autoscaling | 06de20e170853b515cc6ae986ceb5941f7b34f5e |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_docdb_cluster.docdb_primary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster) | resource |
+| [aws_docdb_cluster_instance.docdb_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster_instance) | resource |
+| [aws_docdb_cluster_instance.docdb_replica_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster_instance) | resource |
+| [aws_docdb_subnet_group.private_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_subnet_group) | resource |
+| [aws_kms_key.docdb_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_secretsmanager_secret.master_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.master_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_security_group.service_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [random_password.master_password](https://registry.terraform.io/providers/hashicorp/random/3.4.3/docs/resources/password) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allowed_egress_cidr_blocks"></a> [allowed\_egress\_cidr\_blocks](#input\_allowed\_egress\_cidr\_blocks) | The CIDR blocks to allow egress to | `list(string)` | n/a | yes |
+| <a name="input_allowed_ingress_cidr_blocks"></a> [allowed\_ingress\_cidr\_blocks](#input\_allowed\_ingress\_cidr\_blocks) | The CIDR blocks to allow ingress from | `list(string)` | n/a | yes |
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | The name of the application | `string` | n/a | yes |
+| <a name="input_default_database"></a> [default\_database](#input\_default\_database) | The name of the default database to create | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | The environment to deploy to | `string` | n/a | yes |
+| <a name="input_mongo_name"></a> [mongo\_name](#input\_mongo\_name) | The name of the mongo database | `string` | n/a | yes |
+| <a name="input_primary_instance_class"></a> [primary\_instance\_class](#input\_primary\_instance\_class) | The instance class of the primary instances | `string` | n/a | yes |
+| <a name="input_primary_instances"></a> [primary\_instances](#input\_primary\_instances) | The number of primary instances to create | `number` | n/a | yes |
+| <a name="input_private_subnet_ids"></a> [private\_subnet\_ids](#input\_private\_subnet\_ids) | The IDs of the private subnets to deploy to | `list(string)` | n/a | yes |
+| <a name="input_replica_instance_class"></a> [replica\_instance\_class](#input\_replica\_instance\_class) | The instance class of the replica instances | `string` | n/a | yes |
+| <a name="input_replica_instances"></a> [replica\_instances](#input\_replica\_instances) | The number of replica instances to create | `number` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC to deploy to | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | The cluster identifier |
+| <a name="output_connection_url"></a> [connection\_url](#output\_connection\_url) | The connection url |
+| <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | The connection endpoint |
+| <a name="output_password"></a> [password](#output\_password) | The master password |
+| <a name="output_port"></a> [port](#output\_port) | The connection port |
+| <a name="output_username"></a> [username](#output\_username) | The master username |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/terraform/docdb/autoscaling.tf
+++ b/terraform/docdb/autoscaling.tf
@@ -1,0 +1,16 @@
+module "docdb-autoscaling" {
+  source             = "github.com/theuves/docdb-autoscaling?ref=06de20e170853b515cc6ae986ceb5941f7b34f5e"
+  cluster_identifier = aws_docdb_cluster.docdb_primary.id
+  name               = "${var.environment}-${var.app_name}-docdb-autoscaling"
+  min_capacity       = 0
+  max_capacity       = 6
+
+  scaling_policy = [
+    {
+      metric_name = "CPUUtilization"
+      target      = 80
+      statistic   = "Average"
+      cooldown    = 300
+    }
+  ]
+}

--- a/terraform/docdb/main.tf
+++ b/terraform/docdb/main.tf
@@ -1,18 +1,3 @@
-terraform {
-  required_version = "~> 1.0"
-
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.27"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.4.3"
-    }
-  }
-}
-
 locals {
   name_prefix     = replace("${var.environment}-${var.app_name}-${var.mongo_name}", "_", "-")
   master_password = aws_secretsmanager_secret_version.master_password.secret_string
@@ -61,6 +46,15 @@ resource "aws_docdb_cluster_instance" "docdb_instances" {
   instance_class     = var.primary_instance_class
   promotion_tier     = 0
 }
+
+resource "aws_docdb_cluster_instance" "docdb_replica_instances" {
+  count              = var.replica_instances
+  identifier         = "${local.name_prefix}-replica-instance-${count.index}"
+  cluster_identifier = aws_docdb_cluster.docdb_primary.id
+  instance_class     = var.replica_instance_class
+  promotion_tier     = 1
+}
+
 
 resource "aws_docdb_subnet_group" "private_subnets" {
   name       = "${local.name_prefix}-private-subnet-group"

--- a/terraform/docdb/outputs.tf
+++ b/terraform/docdb/outputs.tf
@@ -1,23 +1,29 @@
 output "endpoint" {
-  value = aws_docdb_cluster.docdb_primary.endpoint
+  description = "The connection endpoint"
+  value       = aws_docdb_cluster.docdb_primary.endpoint
 }
 
 output "username" {
-  value = aws_docdb_cluster.docdb_primary.master_username
+  description = "The master username"
+  value       = aws_docdb_cluster.docdb_primary.master_username
 }
 
 output "password" {
-  value = aws_docdb_cluster.docdb_primary.master_password
+  description = "The master password"
+  value       = aws_docdb_cluster.docdb_primary.master_password
 }
 
 output "port" {
-  value = aws_docdb_cluster.docdb_primary.port
+  description = "The connection port"
+  value       = aws_docdb_cluster.docdb_primary.port
 }
 
 output "connection_url" {
-  value = "mongodb://${aws_docdb_cluster.docdb_primary.master_username}:${aws_docdb_cluster.docdb_primary.master_password}@${aws_docdb_cluster.docdb_primary.endpoint}:${aws_docdb_cluster.docdb_primary.port}/${var.default_database}?tls=true&tlsCaFile=rds-combined-ca-bundle.pem&tlsAllowInvalidCertificates=true&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false&minPoolSize=32&maxPoolSize=256&maxIdleTimeMS=30000&connectTimeoutMS=30000"
+  description = "The connection url"
+  value       = "mongodb://${aws_docdb_cluster.docdb_primary.master_username}:${aws_docdb_cluster.docdb_primary.master_password}@${aws_docdb_cluster.docdb_primary.endpoint}:${aws_docdb_cluster.docdb_primary.port}/${var.default_database}?tls=true&tlsCaFile=rds-combined-ca-bundle.pem&tlsAllowInvalidCertificates=true&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false&minPoolSize=32&maxPoolSize=256&maxIdleTimeMS=30000&connectTimeoutMS=30000"
 }
 
 output "cluster_id" {
-  value = aws_docdb_cluster.docdb_primary.cluster_identifier
+  description = "The cluster identifier"
+  value       = aws_docdb_cluster.docdb_primary.cluster_identifier
 }

--- a/terraform/docdb/terraform.tf
+++ b/terraform/docdb/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.27"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.4.3"
+    }
+  }
+}

--- a/terraform/docdb/variables.tf
+++ b/terraform/docdb/variables.tf
@@ -1,39 +1,59 @@
-variable "mongo_name" {
-  type = string
+variable "environment" {
+  description = "The environment to deploy to"
+  type        = string
 }
 
 variable "app_name" {
-  type = string
+  description = "The name of the application"
+  type        = string
 }
 
-variable "environment" {
-  type = string
-}
-
-variable "primary_instance_class" {
-  type = string
+variable "mongo_name" {
+  description = "The name of the mongo database"
+  type        = string
 }
 
 variable "primary_instances" {
-  type = number
+  description = "The number of primary instances to create"
+  type        = number
+}
+
+variable "primary_instance_class" {
+  description = "The instance class of the primary instances"
+  type        = string
+}
+
+variable "replica_instances" {
+  description = "The number of replica instances to create"
+  type        = number
+}
+
+variable "replica_instance_class" {
+  description = "The instance class of the replica instances"
+  type        = string
 }
 
 variable "allowed_ingress_cidr_blocks" {
-  type = list(string)
+  description = "The CIDR blocks to allow ingress from"
+  type        = list(string)
 }
 
 variable "allowed_egress_cidr_blocks" {
-  type = list(string)
-}
-
-variable "private_subnet_ids" {
-  type = list(string)
+  description = "The CIDR blocks to allow egress to"
+  type        = list(string)
 }
 
 variable "vpc_id" {
-  type = string
+  description = "The ID of the VPC to deploy to"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "The IDs of the private subnets to deploy to"
+  type        = list(string)
 }
 
 variable "default_database" {
-  type = string
+  description = "The name of the default database to create"
+  type        = string
 }

--- a/terraform/ecs/autoscaling.tf
+++ b/terraform/ecs/autoscaling.tf
@@ -18,7 +18,7 @@ resource "aws_iam_role" "ecs_autoscaling_role" {
 resource "aws_appautoscaling_target" "ecs_target" {
   min_capacity       = var.min_capacity
   max_capacity       = var.max_capacity
-  resource_id        = aws_ecs_service.app_service.id // "service/app_clustername/app_servicename"
+  resource_id        = "service/${aws_ecs_cluster.app_cluster.name}/${aws_ecs_service.app_service.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
   role_arn           = aws_iam_role.ecs_autoscaling_role.arn

--- a/terraform/ecs/autoscaling.tf
+++ b/terraform/ecs/autoscaling.tf
@@ -1,0 +1,57 @@
+data "aws_iam_policy_document" "ecs_autoscaling_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["application-autoscaling.amazonaws.com"]
+    }
+  }
+}
+resource "aws_iam_role" "ecs_autoscaling_role" {
+  name = "${var.app_name}-ecs-scale-application"
+
+  assume_role_policy = data.aws_iam_policy_document.ecs_autoscaling_policy.json
+}
+
+resource "aws_appautoscaling_target" "ecs_target" {
+  min_capacity       = var.min_capacity
+  max_capacity       = var.max_capacity
+  resource_id        = aws_ecs_service.app_service.id // "service/app_clustername/app_servicename"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+  role_arn           = aws_iam_role.ecs_autoscaling_role.arn
+}
+
+resource "aws_appautoscaling_policy" "ecs_target_cpu" {
+  name               = "application-scaling-policy-cpu"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.ecs_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs_target.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs_target.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    target_value = 80
+  }
+  depends_on = [aws_appautoscaling_target.ecs_target]
+}
+
+resource "aws_appautoscaling_policy" "ecs_target_memory" {
+  name               = "application-scaling-policy-memory"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.ecs_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs_target.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs_target.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
+    }
+    target_value = 80
+  }
+  depends_on = [aws_appautoscaling_target.ecs_target]
+}

--- a/terraform/ecs/dns.tf
+++ b/terraform/ecs/dns.tf
@@ -1,0 +1,12 @@
+# DNS Records
+resource "aws_route53_record" "dns_load_balancer" {
+  zone_id = var.route53_zone_id
+  name    = var.fqdn
+  type    = "A"
+
+  alias {
+    name                   = aws_alb.network_load_balancer.dns_name
+    zone_id                = aws_alb.network_load_balancer.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -1,14 +1,3 @@
-terraform {
-  required_version = "~> 1.0"
-
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.27"
-    }
-  }
-}
-
 locals {
   image = "${var.ecr_repository_url}:${var.image_version}"
 }
@@ -152,7 +141,7 @@ resource "aws_ecs_service" "app_service" {
   cluster         = aws_ecs_cluster.app_cluster.id
   task_definition = join(":", slice(split(":", aws_ecs_task_definition.app_task.arn), 0, 6))
   launch_type     = "FARGATE"
-  desired_count   = 2
+  desired_count   = var.min_capacity
 
   # Wait for the service deployment to succeed
   wait_for_steady_state = true
@@ -172,116 +161,5 @@ resource "aws_ecs_service" "app_service" {
   # Allow external changes without Terraform plan difference
   lifecycle {
     ignore_changes = [desired_count]
-  }
-}
-
-# Load Balancer
-#tfsec:ignore:aws-elb-alb-not-public
-resource "aws_alb" "network_load_balancer" {
-  name               = replace("${var.app_name}-lb-${substr(uuid(), 0, 3)}", "_", "-")
-  load_balancer_type = "network"
-  subnets            = var.public_subnet_ids
-
-  lifecycle {
-    create_before_destroy = true
-    ignore_changes        = [name]
-  }
-}
-
-resource "aws_lb_target_group" "target_group" {
-  name        = replace("${var.app_name}-${substr(uuid(), 0, 3)}", "_", "-")
-  port        = var.port
-  protocol    = "TCP"
-  target_type = "ip"
-  vpc_id      = var.vpc_id
-
-  # Deregister quickly to allow for faster deployments
-  deregistration_delay = 30 # Seconds
-
-  health_check {
-    protocol            = "HTTP"
-    path                = "/health"
-    interval            = 10
-    healthy_threshold   = 2
-    unhealthy_threshold = 2
-  }
-
-  lifecycle {
-    create_before_destroy = true
-    ignore_changes        = [name]
-  }
-}
-
-resource "aws_lb_listener" "listener" {
-  load_balancer_arn = aws_alb.network_load_balancer.arn
-  port              = "443"
-  protocol          = "TLS"
-  certificate_arn   = var.acm_certificate_arn
-  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
-  default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.target_group.arn
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-# Security Groups
-resource "aws_security_group" "tls_ingess" {
-  name        = "${var.app_name}-tls-ingress"
-  description = "Allow tls ingress from everywhere"
-  vpc_id      = var.vpc_id
-
-  ingress { #tfsec:ignore:aws-ec2-add-description-to-security-group-rule
-    from_port = 443
-    to_port   = 443
-    protocol  = "tcp"
-    #tfsec:ignore:aws-ec2-no-public-ingress-sgr
-    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic in from all sources
-  }
-
-  egress {           #tfsec:ignore:aws-ec2-add-description-to-security-group-rule
-    from_port = 0    # Allowing any incoming port
-    to_port   = 0    # Allowing any outgoing port
-    protocol  = "-1" # Allowing any outgoing protocol
-    #tfsec:ignore:aws-ec2-no-public-egress-sgr
-    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic out to all IP addresses
-  }
-}
-
-resource "aws_security_group" "vpc_app_ingress" {
-  name        = "${var.app_name}-vpc-ingress-to-app"
-  description = "Allow app port ingress from vpc"
-  vpc_id      = var.vpc_id
-
-  ingress { #tfsec:ignore:aws-ec2-add-description-to-security-group-rule
-    from_port   = var.port
-    to_port     = var.port
-    protocol    = "tcp"
-    cidr_blocks = var.allowed_ingress_cidr_blocks
-  }
-
-  egress {           #tfsec:ignore:aws-ec2-add-description-to-security-group-rule
-    from_port = 0    # Allowing any incoming port
-    to_port   = 0    # Allowing any outgoing port
-    protocol  = "-1" # Allowing any outgoing protocol
-    #tfsec:ignore:aws-ec2-no-public-egress-sgr
-    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic out to all IP addresses
-  }
-}
-
-
-# DNS Records
-resource "aws_route53_record" "dns_load_balancer" {
-  zone_id = var.route53_zone_id
-  name    = var.fqdn
-  type    = "A"
-
-  alias {
-    name                   = aws_alb.network_load_balancer.dns_name
-    zone_id                = aws_alb.network_load_balancer.zone_id
-    evaluate_target_health = true
   }
 }

--- a/terraform/ecs/network.tf
+++ b/terraform/ecs/network.tf
@@ -1,0 +1,96 @@
+# Load Balancer
+#tfsec:ignore:aws-elb-alb-not-public
+resource "aws_alb" "network_load_balancer" {
+  name               = replace("${var.app_name}-lb-${substr(uuid(), 0, 3)}", "_", "-")
+  load_balancer_type = "network"
+  subnets            = var.public_subnet_ids
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [name]
+  }
+}
+
+resource "aws_lb_target_group" "target_group" {
+  name        = replace("${var.app_name}-${substr(uuid(), 0, 3)}", "_", "-")
+  port        = var.port
+  protocol    = "TCP"
+  target_type = "ip"
+  vpc_id      = var.vpc_id
+
+  # Deregister quickly to allow for faster deployments
+  deregistration_delay = 30 # Seconds
+
+  health_check {
+    protocol            = "HTTP"
+    path                = "/health"
+    interval            = 10
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [name]
+  }
+}
+
+resource "aws_lb_listener" "listener" {
+  load_balancer_arn = aws_alb.network_load_balancer.arn
+  port              = "443"
+  protocol          = "TLS"
+  certificate_arn   = var.acm_certificate_arn
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.target_group.arn
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Security Groups
+resource "aws_security_group" "tls_ingess" {
+  name        = "${var.app_name}-tls-ingress"
+  description = "Allow tls ingress from everywhere"
+  vpc_id      = var.vpc_id
+
+  ingress { #tfsec:ignore:aws-ec2-add-description-to-security-group-rule
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+    #tfsec:ignore:aws-ec2-no-public-ingress-sgr
+    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic in from all sources
+  }
+
+  egress {           #tfsec:ignore:aws-ec2-add-description-to-security-group-rule
+    from_port = 0    # Allowing any incoming port
+    to_port   = 0    # Allowing any outgoing port
+    protocol  = "-1" # Allowing any outgoing protocol
+    #tfsec:ignore:aws-ec2-no-public-egress-sgr
+    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic out to all IP addresses
+  }
+}
+
+resource "aws_security_group" "vpc_app_ingress" {
+  name        = "${var.app_name}-vpc-ingress-to-app"
+  description = "Allow app port ingress from vpc"
+  vpc_id      = var.vpc_id
+
+  ingress { #tfsec:ignore:aws-ec2-add-description-to-security-group-rule
+    from_port   = var.port
+    to_port     = var.port
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_ingress_cidr_blocks
+  }
+
+  egress {           #tfsec:ignore:aws-ec2-add-description-to-security-group-rule
+    from_port = 0    # Allowing any incoming port
+    to_port   = 0    # Allowing any outgoing port
+    protocol  = "-1" # Allowing any outgoing protocol
+    #tfsec:ignore:aws-ec2-no-public-egress-sgr
+    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic out to all IP addresses
+  }
+}

--- a/terraform/ecs/terraform.tf
+++ b/terraform/ecs/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.27"
+    }
+  }
+}

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -1,3 +1,13 @@
+variable "min_capacity" {
+  type    = number
+  default = 2
+}
+
+variable "max_capacity" {
+  type    = number
+  default = 8
+}
+
 variable "ecr_repository_url" {
   type = string
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -60,8 +60,10 @@ module "keystore-docdb" {
   mongo_name                  = "keystore-docdb"
   environment                 = terraform.workspace
   default_database            = "keystore"
-  primary_instance_class      = var.keystore_docdb_primary_instance_class
   primary_instances           = var.keystore_docdb_primary_instances
+  primary_instance_class      = var.keystore_docdb_primary_instance_class
+  replica_instances           = var.keystore_docdb_replica_instances
+  replica_instance_class      = var.keystore_docdb_replica_instance_class
   vpc_id                      = data.aws_vpc.vpc.id
   private_subnet_ids          = data.aws_subnets.private_subnets.ids
   allowed_ingress_cidr_blocks = [data.aws_vpc.vpc.cidr_block]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -68,7 +68,6 @@ module "keystore-docdb" {
   allowed_egress_cidr_blocks  = [data.aws_vpc.vpc.cidr_block]
 }
 
-
 module "o11y" {
   source = "./monitoring"
 

--- a/terraform/monitoring/panels/app/healthy_hosts.libsonnet
+++ b/terraform/monitoring/panels/app/healthy_hosts.libsonnet
@@ -19,10 +19,11 @@ local _configuration = defaults.configuration.timeseries
     .configure(_configuration)
 
     .addTarget(targets.cloudwatch(
+      alias           = 'Hosts Count',
       metricQueryType = grafana.target.cloudwatch.metricQueryTypes.query,
       datasource      = ds.cloudwatch,
-      namespace     = 'AWS/NetworkELB',
-      metricName    = 'HealthyHostCount',
+      namespace       = 'AWS/NetworkELB',
+      metricName      = 'HealthyHostCount',
 
       sql           = {
         from: {

--- a/terraform/monitoring/panels/docdb/available_memory.libsonnet
+++ b/terraform/monitoring/panels/docdb/available_memory.libsonnet
@@ -6,8 +6,8 @@ local alertCondition  = grafana.alertCondition;
 
 local defaults        = import '../defaults.libsonnet';
 
-local mem_threshold = 5000000000;   // 5GiB
-local max_memory    = 64000000000;  // 64GiB (AWS DocDB max on db.r6g.2xlarge)
+local mem_threshold = 4000000000;   // 4GiB
+local max_memory    = 16000000000;  // 16GiB (AWS DocDB max on db.r6g.large)
 
 local _configuration = defaults.configuration.timeseries
   .withThresholdStyle('area')

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,20 +1,35 @@
 variable "region" {
-  type    = string
-  default = "eu-central-1"
+  description = "AWS region to deploy to"
+  type        = string
+  default     = "eu-central-1"
 }
 
 variable "grafana_endpoint" {
-  type = string
+  description = "The endpoint of the Grafana instance"
+  type        = string
 }
 
 variable "image_version" {
-  type = string
-}
-
-variable "keystore_docdb_primary_instance_class" {
-  type = string
+  description = "The version of the image to deploy"
+  type        = string
 }
 
 variable "keystore_docdb_primary_instances" {
-  type = number
+  description = "The number of primary docdb instances to deploy"
+  type        = number
+}
+
+variable "keystore_docdb_primary_instance_class" {
+  description = "The instance class of the primary docdb instances"
+  type        = string
+}
+
+variable "keystore_docdb_replica_instances" {
+  description = "The number of replica docdb instances to deploy"
+  type        = number
+}
+
+variable "keystore_docdb_replica_instance_class" {
+  description = "The instance class of the replica docdb instances"
+  type        = string
 }

--- a/terraform/vars/dev.tfvars
+++ b/terraform/vars/dev.tfvars
@@ -1,2 +1,2 @@
-keystore_docdb_primary_instance_class = "db.r5.large"
+keystore_docdb_primary_instance_class = "db.r6g.large"
 keystore_docdb_primary_instances      = 1

--- a/terraform/vars/dev.tfvars
+++ b/terraform/vars/dev.tfvars
@@ -1,2 +1,4 @@
-keystore_docdb_primary_instance_class = "db.r6g.large"
 keystore_docdb_primary_instances      = 1
+keystore_docdb_primary_instance_class = "db.r6g.large"
+keystore_docdb_replica_instances      = 0
+keystore_docdb_replica_instance_class = "db.r6g.large"

--- a/terraform/vars/prod.tfvars
+++ b/terraform/vars/prod.tfvars
@@ -1,2 +1,2 @@
-keystore_docdb_primary_instance_class = "db.r5.xlarge"
+keystore_docdb_primary_instance_class = "db.r6g.large"
 keystore_docdb_primary_instances      = 1

--- a/terraform/vars/prod.tfvars
+++ b/terraform/vars/prod.tfvars
@@ -1,2 +1,4 @@
-keystore_docdb_primary_instance_class = "db.r6g.large"
 keystore_docdb_primary_instances      = 1
+keystore_docdb_primary_instance_class = "db.r6g.large"
+keystore_docdb_replica_instances      = 1
+keystore_docdb_replica_instance_class = "db.r6g.large"

--- a/terraform/vars/staging.tfvars
+++ b/terraform/vars/staging.tfvars
@@ -1,2 +1,2 @@
-keystore_docdb_primary_instance_class = "db.r5.large"
+keystore_docdb_primary_instance_class = "db.r6g.large"
 keystore_docdb_primary_instances      = 1

--- a/terraform/vars/staging.tfvars
+++ b/terraform/vars/staging.tfvars
@@ -1,2 +1,4 @@
-keystore_docdb_primary_instance_class = "db.r6g.large"
 keystore_docdb_primary_instances      = 1
+keystore_docdb_primary_instance_class = "db.r6g.large"
+keystore_docdb_replica_instances      = 0
+keystore_docdb_replica_instance_class = "db.r6g.large"


### PR DESCRIPTION
# Description

- #67: Change instance types for DocDB to `db.r6g.large`.
- #74: Add autoscaling for ECS and DocDB replicas.

## How Has This Been Tested?

Deployed manually to staging.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
