### PR TITLE
fix: add image version parameter to dispatch workflow event

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -17,6 +17,11 @@ on:
         required: true
         type: string
         default: https://keys.walletconnect.com/health
+      version:
+        description: 'The ECR tag to deploy e.g. 1.7.0'
+        required: true
+        default: '1.7.0'
+        type: string
   workflow_call:
     inputs:
       environment:


### PR DESCRIPTION
# Description

The dispatch workflow event for `deploy_infra` lacks the `version` parameter which leads to failing deployments ("failed to normalize image reference").
Adds that parameter to enable manual infra deployments.

## How Has This Been Tested?

Not tested (CI)

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
